### PR TITLE
fix: position index for lists

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.13.4-otp-25
+erlang 25.1

--- a/lib/ex_workerbook/builder.ex
+++ b/lib/ex_workerbook/builder.ex
@@ -37,14 +37,12 @@ defmodule ExWorkerbook.Builder do
   """
   def build(builder, options \\ []) do
     builder.jobs
-    |> Enum.map(&put_job_plugins_result(&1, options))
+    |> Enum.map(&put_job_result/1)
     |> Enum.reduce(builder, &render_job(&1, &2, options))
   end
 
-  defp put_job_plugins_result(job, options) do
-    options = Keyword.merge(job.options, options)
-    result = Plugins.call(job.arg, options)
-
+  defp put_job_result(job) do
+    result = Plugins.call(job.arg, job.options)
     Map.put(job, :result, result)
   end
 

--- a/lib/ex_workerbook/plugins/styles.ex
+++ b/lib/ex_workerbook/plugins/styles.ex
@@ -1,6 +1,8 @@
 defmodule ExWorkerbook.Plugins.Styles do
   @behaviour ExWorkerbook.Plugins
 
+  require Integer
+
   @impl ExWorkerbook.Plugins
   def call(values, options \\ []) do
     Enum.reduce(options, values, &maybe_transform_values/2)
@@ -30,16 +32,16 @@ defmodule ExWorkerbook.Plugins.Styles do
     case rows do
       [{:key, _, _, _} | _] ->
         if action === :odd do
-          transform_map_opts(rows, opts, &odd?/1)
+          transform_map_opts(rows, opts, &Integer.is_odd/1)
         else
-          transform_map_opts(rows, opts, &even?/1)
+          transform_map_opts(rows, opts, &Integer.is_even/1)
         end
 
       [{:value, _, _, _} | _] ->
         if action === :odd do
-          transform_list_opts(rows, opts, &odd?/1)
+          transform_list_opts(rows, opts, &Integer.is_odd/1)
         else
-          transform_list_opts(rows, opts, &even?/1)
+          transform_list_opts(rows, opts, &Integer.is_even/1)
         end
     end
   end
@@ -120,6 +122,4 @@ defmodule ExWorkerbook.Plugins.Styles do
     {type, id, value, sheet_opts}
   end
 
-  defp even?(num), do: rem(num, 2) === 0
-  defp odd?(num), do: !even?(num)
 end


### PR DESCRIPTION
fixes a bug that caused the `pos` option to select all except the specified position for list values.